### PR TITLE
preserve pre-migration transaction allocations during reprocess

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/AbstractLoanRepaymentScheduleTransactionProcessor.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/AbstractLoanRepaymentScheduleTransactionProcessor.java
@@ -36,6 +36,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.configuration.service.TemporaryConfigurationServiceContainer;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
@@ -54,6 +55,7 @@ import org.apache.fineract.portfolio.loanaccount.domain.LoanInstallmentCharge;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleProcessingWrapper;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanTransaction;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionComparator;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionRelation;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionRelationTypeEnum;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionToRepaymentScheduleMapping;
@@ -77,6 +79,7 @@ import org.springframework.util.CollectionUtils;
  * @see HeavensFamilyLoanRepaymentScheduleTransactionProcessor
  * @see CreocoreLoanRepaymentScheduleTransactionProcessor
  */
+@Slf4j
 @RequiredArgsConstructor
 public abstract class AbstractLoanRepaymentScheduleTransactionProcessor implements LoanRepaymentScheduleTransactionProcessor {
 
@@ -107,6 +110,39 @@ public abstract class AbstractLoanRepaymentScheduleTransactionProcessor implemen
     public ChangedTransactionDetail reprocessLoanTransactions(final LocalDate disbursementDate,
             final List<LoanTransaction> transactionsPostDisbursement, final MonetaryCurrency currency,
             final List<LoanRepaymentScheduleInstallment> installments, final Set<LoanCharge> charges) {
+        return reprocessLoanTransactions(disbursementDate, transactionsPostDisbursement, currency, installments, charges, null);
+    }
+
+    @Override
+    public ChangedTransactionDetail reprocessLoanTransactions(final LocalDate disbursementDate,
+            final List<LoanTransaction> transactionsPostDisbursement, final MonetaryCurrency currency,
+            final List<LoanRepaymentScheduleInstallment> installments, final Set<LoanCharge> charges, final LocalDate migrationCutoffDate) {
+
+        // Partition transactions into pre-migration (immutable) and post-cutoff (strategy-replayed). When the cutoff
+        // is null, the loan is not within the migrated range; all transactions go through the strategy as before.
+        //
+        // Only repayment-like and charge-payment transactions are eligible for replay-via-mappings. Pre-cutoff
+        // transactions of other types (write-off, refund, chargeback, charge-off, charges/interest waiver, credit
+        // balance refund, etc.) carry semantics that the paid-amount installment methods do not express (e.g.,
+        // write-off uses writePrincipalOff, not payPrincipalComponent). Routing them through the strategy preserves
+        // their existing handlers.
+        final List<LoanTransaction> migratedTransactions;
+        final List<LoanTransaction> currentTransactions;
+        if (migrationCutoffDate != null) {
+            migratedTransactions = new ArrayList<>();
+            currentTransactions = new ArrayList<>();
+            for (final LoanTransaction loanTransaction : transactionsPostDisbursement) {
+                if (DateUtils.isBefore(loanTransaction.getTransactionDate(), migrationCutoffDate)
+                        && isReplayableViaMigratedMappings(loanTransaction)) {
+                    migratedTransactions.add(loanTransaction);
+                } else {
+                    currentTransactions.add(loanTransaction);
+                }
+            }
+        } else {
+            migratedTransactions = Collections.emptyList();
+            currentTransactions = new ArrayList<>(transactionsPostDisbursement);
+        }
 
         if (charges != null) {
             for (final LoanCharge loanCharge : charges) {
@@ -127,9 +163,19 @@ public abstract class AbstractLoanRepaymentScheduleTransactionProcessor implemen
         final LoanRepaymentScheduleProcessingWrapper wrapper = new LoanRepaymentScheduleProcessingWrapper();
         wrapper.reprocess(currency, disbursementDate, installments, charges);
 
+        // Replay migrated (pre-cutoff) transactions using their stored allocations, in chronological order. The
+        // strategy is intentionally bypassed so that the FinFlux-era principal/interest/fee/penalty splits are
+        // preserved as the authoritative historical state.
+        if (!migratedTransactions.isEmpty()) {
+            migratedTransactions.sort(LoanTransactionComparator.INSTANCE);
+            for (final LoanTransaction migratedTransaction : migratedTransactions) {
+                applyMigratedTransactionToSchedule(migratedTransaction, currency, charges);
+            }
+        }
+
         final ChangedTransactionDetail changedTransactionDetail = new ChangedTransactionDetail();
         final List<LoanTransaction> transactionsToBeProcessed = new ArrayList<>();
-        for (final LoanTransaction loanTransaction : transactionsPostDisbursement) {
+        for (final LoanTransaction loanTransaction : currentTransactions) {
             if (loanTransaction.isChargePayment()) {
                 List<LoanChargePaidDetail> chargePaidDetails = new ArrayList<>();
                 final Set<LoanChargePaidBy> chargePaidBies = loanTransaction.getLoanChargesPaid();
@@ -242,8 +288,140 @@ public abstract class AbstractLoanRepaymentScheduleTransactionProcessor implemen
                 recalculateChargeOffTransaction(changedTransactionDetail, loanTransaction, currency, installments);
             }
         }
-        reprocessInstallments(disbursementDate, transactionsToBeProcessed, installments, currency);
+        // reprocessInstallments scans the transactions list for the last charge-waiver to update obligationsMet on
+        // the final installment. Pre-cutoff charge-waiver transactions sit in `currentTransactions` (replay-via-
+        // mappings is gated to paid-amount semantics only), so the union here is `migratedTransactions` +
+        // `transactionsToBeProcessed`. Note that `transactionsToBeProcessed` already excludes charge-payments — those
+        // were handled inline above and don't affect obligationsMet logic.
+        final List<LoanTransaction> transactionsForInstallmentReprocess;
+        if (migratedTransactions.isEmpty()) {
+            transactionsForInstallmentReprocess = transactionsToBeProcessed;
+        } else {
+            transactionsForInstallmentReprocess = new ArrayList<>(migratedTransactions.size() + transactionsToBeProcessed.size());
+            transactionsForInstallmentReprocess.addAll(migratedTransactions);
+            transactionsForInstallmentReprocess.addAll(transactionsToBeProcessed);
+        }
+        reprocessInstallments(disbursementDate, transactionsForInstallmentReprocess, installments, currency);
         return changedTransactionDetail;
+    }
+
+    /**
+     * Returns {@code true} when the transaction's allocation is expressible via the installment paid-amount methods
+     * ({@code payPrincipalComponent} etc.) — i.e., repayment-like or charge-payment. Other types (write-off, refund,
+     * chargeback, charge-off, charges/interest waiver, credit balance refund, accrual variants) carry semantics that
+     * paid-amount methods do not capture and must flow through the strategy / specific handlers.
+     * <p>
+     * {@code isInterestWaiver()} is intentionally excluded: WAIVE_INTEREST uses {@code waiveInterestComponent}, not
+     * {@code payInterestComponent}. Pre-cutoff WAIVE_INTEREST transactions are routed through the strategy and
+     * re-derived against the post-migrated-repayment state. For typical migrated loans (no waivers) this has no impact;
+     * if a migrated loan does contain a waiver, the waiver amount may shift to match current outstanding.
+     * </p>
+     * <p>
+     * <b>Ordering limitation:</b> Migrated transactions are replayed FIRST (lines 169-174), then current transactions
+     * in their chronological order. If a pre-cutoff non-replayable transaction (e.g., a non-terminal write-off) sits
+     * chronologically between two migrated repayments, it will be applied AFTER all migrated repayments instead of in
+     * true chronological position. For terminal write-offs (the typical case) this is a non-issue. A strictly
+     * chronological pass would require merging the migrated-replay into the existing transaction loop — deferred to
+     * Part 2 if migrated loans with mid-stream write-offs / chargebacks are encountered.
+     * </p>
+     */
+    private static boolean isReplayableViaMigratedMappings(final LoanTransaction t) {
+        return t.isRepaymentLikeType() || t.isRecoveryRepayment() || t.isChargePayment();
+    }
+
+    /**
+     * Replays a pre-migration transaction onto the (already-reset) schedule using its existing
+     * {@link LoanTransactionToRepaymentScheduleMapping} rows and {@link LoanChargePaidBy} links. The strategy is
+     * intentionally bypassed: the migrated allocation is treated as the authoritative historical state and is NOT
+     * re-derived from current schedule conditions. Charge {@code amountPaid} values are re-linked via the transaction's
+     * {@code LoanChargePaidBy} rows that survived {@link LoanCharge#resetPaidAmount(MonetaryCurrency)}.
+     * <p>
+     * <b>Deliberate trade-off:</b> {@link LoanTransaction#adjustInterestComponent()} is NOT invoked on the migrated
+     * transaction. That method reconciles rounding drift between the transaction-level {@code interestPortion} and the
+     * sum of mapped portions, using the current Fineract rounding/unrecognised-income conventions. Migrated
+     * transactions were stored using the source system's conventions; reapplying Fineract's adjustment would mutate the
+     * authoritative historical interest portion. The component-sum validation below catches gross mis-storage.
+     * </p>
+     * <p>
+     * If the mapping portions do not sum to the transaction amount, a warning is logged and the transaction is skipped.
+     * This guards against bad migration data corrupting the schedule but does not break the overall reprocess for other
+     * transactions on the loan.
+     * </p>
+     */
+    private void applyMigratedTransactionToSchedule(final LoanTransaction migratedTransaction, final MonetaryCurrency currency,
+            final Set<LoanCharge> charges) {
+
+        final Set<LoanTransactionToRepaymentScheduleMapping> mappings = migratedTransaction.getLoanTransactionToRepaymentScheduleMappings();
+        if (mappings == null || mappings.isEmpty()) {
+            // Nothing to replay (e.g., disbursement-only or non-monetary), leave components untouched.
+            return;
+        }
+
+        final Money transactionAmount = migratedTransaction.getAmount(currency);
+        Money mappedSum = Money.zero(currency);
+        for (final LoanTransactionToRepaymentScheduleMapping mapping : mappings) {
+            mappedSum = mappedSum.plus(mapping.getPrincipalPortion(currency)).plus(mapping.getInterestPortion(currency))
+                    .plus(mapping.getFeeChargesPortion(currency)).plus(mapping.getPenaltyChargesPortion(currency));
+        }
+        if (!mappedSum.isEqualTo(transactionAmount)) {
+            final Long loanId = migratedTransaction.getLoan() != null ? migratedTransaction.getLoan().getId() : null;
+            log.warn(
+                    "Skipping migrated transaction replay: loanId={}, transactionId={}, transactionDate={}, transactionAmount={}, mappedSum={}",
+                    loanId, migratedTransaction.getId(), migratedTransaction.getTransactionDate(), transactionAmount.getAmount(),
+                    mappedSum.getAmount());
+            return;
+        }
+
+        final LocalDate transactionDate = migratedTransaction.getTransactionDate();
+        for (final LoanTransactionToRepaymentScheduleMapping mapping : mappings) {
+            final LoanRepaymentScheduleInstallment installment = mapping.getLoanRepaymentScheduleInstallment();
+            if (installment == null) {
+                continue;
+            }
+            applyMigratedComponentToInstallment(installment, transactionDate, mapping.getInterestPortion(currency), "interest",
+                    migratedTransaction, installment::payInterestComponent);
+            applyMigratedComponentToInstallment(installment, transactionDate, mapping.getPrincipalPortion(currency), "principal",
+                    migratedTransaction, installment::payPrincipalComponent);
+            applyMigratedComponentToInstallment(installment, transactionDate, mapping.getFeeChargesPortion(currency), "fee",
+                    migratedTransaction, installment::payFeeChargesComponent);
+            applyMigratedComponentToInstallment(installment, transactionDate, mapping.getPenaltyChargesPortion(currency), "penalty",
+                    migratedTransaction, installment::payPenaltyChargesComponent);
+        }
+
+        // Re-link LoanCharge.amountPaid via the existing LoanChargePaidBy rows (these survive resetPaidAmount).
+        if (charges != null && !charges.isEmpty()) {
+            for (final LoanChargePaidBy chargePaidBy : migratedTransaction.getLoanChargesPaid()) {
+                final LoanCharge loanCharge = chargePaidBy.getLoanCharge();
+                if (loanCharge == null || chargePaidBy.getAmount() == null) {
+                    continue;
+                }
+                final Money incrementBy = Money.of(currency, chargePaidBy.getAmount());
+                if (incrementBy.isZero()) {
+                    continue;
+                }
+                loanCharge.updatePaidAmountBy(incrementBy, chargePaidBy.getInstallmentNumber(), incrementBy);
+            }
+        }
+    }
+
+    private interface InstallmentPayFn {
+
+        Money apply(LocalDate transactionDate, Money amount);
+    }
+
+    private void applyMigratedComponentToInstallment(final LoanRepaymentScheduleInstallment installment, final LocalDate transactionDate,
+            final Money portion, final String componentName, final LoanTransaction migratedTransaction, final InstallmentPayFn payFn) {
+        if (portion.isZero()) {
+            return;
+        }
+        final Money applied = payFn.apply(transactionDate, portion);
+        if (applied.isLessThan(portion)) {
+            final Long loanId = migratedTransaction.getLoan() != null ? migratedTransaction.getLoan().getId() : null;
+            log.warn(
+                    "Migrated transaction {} on loan {} short-applied {} portion to installment {}: requested={}, applied={} (installment outstanding insufficient — migration data may be inconsistent)",
+                    migratedTransaction.getId(), loanId, componentName, installment.getInstallmentNumber(), portion.getAmount(),
+                    applied.getAmount());
+        }
     }
 
     @Override

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/LoanRepaymentScheduleTransactionProcessor.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/LoanRepaymentScheduleTransactionProcessor.java
@@ -53,6 +53,24 @@ public interface LoanRepaymentScheduleTransactionProcessor {
     ChangedTransactionDetail reprocessLoanTransactions(LocalDate disbursementDate, List<LoanTransaction> repaymentsOrWaivers,
             MonetaryCurrency currency, List<LoanRepaymentScheduleInstallment> repaymentScheduleInstallments, Set<LoanCharge> charges);
 
+    /**
+     * Migration-cutoff-aware overload. Transactions with {@code transactionDate < migrationCutoffDate} are treated as
+     * pre-migration: their stored
+     * {@link org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionToRepaymentScheduleMapping} allocations
+     * are honored as-is and the strategy is NOT re-run for them. Transactions on or after the cutoff (or all
+     * transactions if {@code migrationCutoffDate} is {@code null}) flow through the strategy as in the original method.
+     *
+     * <p>
+     * Default behavior delegates to the cutoff-unaware method — implementations that need migration handling override
+     * this overload.
+     * </p>
+     */
+    default ChangedTransactionDetail reprocessLoanTransactions(LocalDate disbursementDate, List<LoanTransaction> repaymentsOrWaivers,
+            MonetaryCurrency currency, List<LoanRepaymentScheduleInstallment> repaymentScheduleInstallments, Set<LoanCharge> charges,
+            LocalDate migrationCutoffDate) {
+        return reprocessLoanTransactions(disbursementDate, repaymentsOrWaivers, currency, repaymentScheduleInstallments, charges);
+    }
+
     Money handleRepaymentSchedule(List<LoanTransaction> transactionsPostDisbursement, MonetaryCurrency currency,
             List<LoanRepaymentScheduleInstallment> installments, Set<LoanCharge> loanCharges);
 

--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanTransactionProcessingService.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanTransactionProcessingService.java
@@ -46,6 +46,17 @@ public interface LoanTransactionProcessingService {
             List<LoanTransaction> repaymentsOrWaivers, MonetaryCurrency currency,
             List<LoanRepaymentScheduleInstallment> repaymentScheduleInstallments, Set<LoanCharge> charges);
 
+    /**
+     * Migration-cutoff-aware overload. When {@code migrationCutoffDate} is non-null, transactions with
+     * {@code transactionDate < migrationCutoffDate} are honored as-is (their stored allocations are preserved) and only
+     * transactions on or after the cutoff flow through the strategy. Loans handled by the advanced (progressive
+     * interest) processor do not honor the migration cutoff — see {@code LoanTransactionProcessingServiceImpl} for the
+     * dispatching warn.
+     */
+    ChangedTransactionDetail reprocessLoanTransactions(String transactionProcessingStrategyCode, LocalDate disbursementDate,
+            List<LoanTransaction> repaymentsOrWaivers, MonetaryCurrency currency,
+            List<LoanRepaymentScheduleInstallment> repaymentScheduleInstallments, Set<LoanCharge> charges, LocalDate migrationCutoffDate);
+
     LoanRepaymentScheduleTransactionProcessor getTransactionProcessor(String transactionProcessingStrategyCode);
 
     Optional<ChangedTransactionDetail> processPostDisbursementTransactions(Loan loan);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanTransactionProcessingServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanTransactionProcessingServiceImpl.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
@@ -48,6 +49,7 @@ import org.apache.fineract.portfolio.loanaccount.loanschedule.data.LoanScheduleD
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanApplicationTerms;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.domain.LoanScheduleGenerator;
 import org.apache.fineract.portfolio.loanaccount.mapper.LoanTermVariationsMapper;
+import org.apache.fineract.portfolio.loanaccount.service.strategy.OverdueChargeCutoffDateResolver;
 import org.apache.fineract.portfolio.loanproduct.calc.data.ProgressiveLoanInterestScheduleModel;
 import org.apache.fineract.portfolio.loanproduct.domain.InterestMethod;
 import org.apache.fineract.portfolio.loanproduct.service.LoanProductRoundingModeService;
@@ -55,6 +57,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.ObjectUtils;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class LoanTransactionProcessingServiceImpl implements LoanTransactionProcessingService {
@@ -65,6 +68,7 @@ public class LoanTransactionProcessingServiceImpl implements LoanTransactionProc
     private final LoanBalanceService loanBalanceService;
     private final LoanTransactionService loanTransactionService;
     private final LoanProductRoundingModeService loanProductRoundingModeService;
+    private final OverdueChargeCutoffDateResolver overdueChargeCutoffDateResolver;
 
     @Override
     public boolean canProcessLatestTransactionOnly(Loan loan, LoanTransaction loanTransaction,
@@ -151,9 +155,23 @@ public class LoanTransactionProcessingServiceImpl implements LoanTransactionProc
     public ChangedTransactionDetail reprocessLoanTransactions(String transactionProcessingStrategyCode, LocalDate disbursementDate,
             List<LoanTransaction> loanTransactions, MonetaryCurrency currency, List<LoanRepaymentScheduleInstallment> installments,
             Set<LoanCharge> charges) {
+        return reprocessLoanTransactions(transactionProcessingStrategyCode, disbursementDate, loanTransactions, currency, installments,
+                charges, null);
+    }
+
+    @Override
+    public ChangedTransactionDetail reprocessLoanTransactions(String transactionProcessingStrategyCode, LocalDate disbursementDate,
+            List<LoanTransaction> loanTransactions, MonetaryCurrency currency, List<LoanRepaymentScheduleInstallment> installments,
+            Set<LoanCharge> charges, LocalDate migrationCutoffDate) {
         final LoanRepaymentScheduleTransactionProcessor loanRepaymentScheduleTransactionProcessor = getTransactionProcessor(
                 transactionProcessingStrategyCode);
         if (loanRepaymentScheduleTransactionProcessor instanceof AdvancedPaymentScheduleTransactionProcessor advancedProcessor) {
+            if (migrationCutoffDate != null) {
+                final Loan loan = getLoan(loanTransactions, installments, charges);
+                log.warn(
+                        "Migration cutoff ({}) is not honored by AdvancedPaymentScheduleTransactionProcessor; migrated loan {} will be reprocessed with strategy reallocation",
+                        migrationCutoffDate, loan != null ? loan.getId() : null);
+            }
             LocalDate currentDate = DateUtils.getBusinessLocalDate();
             Pair<ChangedTransactionDetail, ProgressiveLoanInterestScheduleModel> result = advancedProcessor
                     .reprocessProgressiveLoanTransactions(disbursementDate, currentDate, loanTransactions, currency, installments, charges);
@@ -163,7 +181,7 @@ public class LoanTransactionProcessingServiceImpl implements LoanTransactionProc
             return result.getLeft();
         } else {
             return loanRepaymentScheduleTransactionProcessor.reprocessLoanTransactions(disbursementDate, loanTransactions, currency,
-                    installments, charges);
+                    installments, charges, migrationCutoffDate);
         }
     }
 
@@ -189,9 +207,10 @@ public class LoanTransactionProcessingServiceImpl implements LoanTransactionProc
         for (LoanTransaction loanTransaction : allNonContraTransactionsPostDisbursement) {
             copyTransactions.add(LoanTransaction.copyTransactionProperties(loanTransaction));
         }
+        final LocalDate migrationCutoffDate = overdueChargeCutoffDateResolver.getMigrationCutoffDateOrNull(loan);
         final ChangedTransactionDetail changedTransactionDetail = loanRepaymentScheduleTransactionProcessor.reprocessLoanTransactions(
                 loan.getDisbursementDate(), copyTransactions, loan.getCurrency(), loan.getRepaymentScheduleInstallments(),
-                loan.getActiveCharges());
+                loan.getActiveCharges(), migrationCutoffDate);
 
         loanBalanceService.updateLoanSummaryDerivedFields(loan);
 

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImpl.java
@@ -208,6 +208,7 @@ import org.apache.fineract.portfolio.loanaccount.serialization.LoanTransactionVa
 import org.apache.fineract.portfolio.loanaccount.serialization.LoanUpdateCommandFromApiJsonDeserializer;
 import org.apache.fineract.portfolio.loanaccount.service.adjustment.LoanAdjustmentParameter;
 import org.apache.fineract.portfolio.loanaccount.service.adjustment.LoanAdjustmentService;
+import org.apache.fineract.portfolio.loanaccount.service.strategy.OverdueChargeCutoffDateResolver;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanProduct;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanSupportedInterestRefundTypes;
 import org.apache.fineract.portfolio.loanproduct.exception.LinkedAccountRequiredException;
@@ -288,6 +289,7 @@ public class LoanWritePlatformServiceJpaRepositoryImpl implements LoanWritePlatf
     private final LoanTransactionProcessingService loanTransactionProcessingService;
     private final LoanBalanceService loanBalanceService;
     private final LoanTransactionService loanTransactionService;
+    private final OverdueChargeCutoffDateResolver overdueChargeCutoffDateResolver;
 
     @Transactional
     @Override
@@ -3112,9 +3114,10 @@ public class LoanWritePlatformServiceJpaRepositoryImpl implements LoanWritePlatf
         loan.addLoanTransaction(chargebackTransaction);
         if (loan.isInterestBearing() && loan.isInterestRecalculationEnabled()) {
             final List<LoanTransaction> transactions = loanTransactionService.retrieveListOfTransactionsForReprocessing(loan);
+            final LocalDate migrationCutoffDate = overdueChargeCutoffDateResolver.getMigrationCutoffDateOrNull(loan);
             loanTransactionProcessingService.reprocessLoanTransactions(loan.getTransactionProcessingStrategyCode(),
                     loan.getDisbursementDate(), transactions, loan.getCurrency(), loan.getRepaymentScheduleInstallments(),
-                    loan.getActiveCharges());
+                    loan.getActiveCharges(), migrationCutoffDate);
         } else {
             loanTransactionProcessingService.processLatestTransaction(loan.getTransactionProcessingStrategyCode(), chargebackTransaction,
                     new TransactionCtx(loan.getCurrency(), loan.getRepaymentScheduleInstallments(), loan.getActiveCharges(),

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/ReprocessLoanTransactionsServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/ReprocessLoanTransactionsServiceImpl.java
@@ -45,6 +45,7 @@ import org.apache.fineract.portfolio.loanaccount.domain.transactionprocessor.Mon
 import org.apache.fineract.portfolio.loanaccount.domain.transactionprocessor.TransactionCtx;
 import org.apache.fineract.portfolio.loanaccount.domain.transactionprocessor.impl.AdvancedPaymentScheduleTransactionProcessor;
 import org.apache.fineract.portfolio.loanaccount.domain.transactionprocessor.impl.ProgressiveTransactionCtx;
+import org.apache.fineract.portfolio.loanaccount.service.strategy.OverdueChargeCutoffDateResolver;
 import org.apache.fineract.portfolio.loanproduct.calc.data.ProgressiveLoanInterestScheduleModel;
 import org.springframework.stereotype.Service;
 
@@ -63,6 +64,7 @@ public class ReprocessLoanTransactionsServiceImpl implements ReprocessLoanTransa
     private final LoanJournalEntryPoster loanJournalEntryPoster;
     private final BusinessEventNotifierService businessEventNotifierService;
     private final LoanAccrualActivityProcessingService loanAccrualActivityProcessingService;
+    private final OverdueChargeCutoffDateResolver overdueChargeCutoffDateResolver;
 
     @Override
     public void reprocessTransactions(final Loan loan) {
@@ -225,9 +227,10 @@ public class ReprocessLoanTransactionsServiceImpl implements ReprocessLoanTransa
 
     private ChangedTransactionDetail reprocessTransactionsAndFetchChangedTransactions(final Loan loan,
             final List<LoanTransaction> loanTransactions) {
+        final LocalDate migrationCutoffDate = overdueChargeCutoffDateResolver.getMigrationCutoffDateOrNull(loan);
         final ChangedTransactionDetail changedTransactionDetail = loanTransactionProcessingService.reprocessLoanTransactions(
                 loan.getTransactionProcessingStrategyCode(), loan.getDisbursementDate(), loanTransactions, loan.getCurrency(),
-                loan.getRepaymentScheduleInstallments(), loan.getActiveCharges());
+                loan.getRepaymentScheduleInstallments(), loan.getActiveCharges(), migrationCutoffDate);
         for (TransactionChangeData change : changedTransactionDetail.getTransactionChanges()) {
             change.getNewTransaction().updateLoan(loan);
         }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/strategy/OverdueChargeCutoffDateResolver.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/strategy/OverdueChargeCutoffDateResolver.java
@@ -69,4 +69,21 @@ public class OverdueChargeCutoffDateResolver {
     public LocalDate getCutoffDate(final Loan loan) {
         return resolveStrategy(loan).getCutoffDate(loan);
     }
+
+    /**
+     * Returns the migration cutoff date only when the loan falls within the migrated range; otherwise returns
+     * {@code null}. Transactions with {@code transactionDate < migrationCutoffDate} are pre-migration and should not be
+     * reallocated by the strategy during reprocess.
+     *
+     * @param loan
+     *            the loan for which to determine the migration cutoff date
+     * @return the migration cutoff date if the loan is within the migrated range, otherwise {@code null}
+     */
+    public LocalDate getMigrationCutoffDateOrNull(final Loan loan) {
+        final OverdueChargeCutoffDateStrategy strategy = resolveStrategy(loan);
+        if (strategy instanceof MigrationDateCutoffDateStrategy) {
+            return strategy.getCutoffDate(loan);
+        }
+        return null;
+    }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/starter/LoanAccountConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/starter/LoanAccountConfiguration.java
@@ -459,7 +459,7 @@ public class LoanAccountConfiguration {
             ReprocessLoanTransactionsService reprocessLoanTransactionsService, LoanAccountService loanAccountService,
             LoanJournalEntryPoster journalEntryPoster, LoanAdjustmentService loanAdjustmentService, LoanMapper loanMapper,
             LoanTransactionProcessingService loanTransactionProcessingService, final LoanBalanceService loanBalanceService,
-            LoanTransactionService loanTransactionService) {
+            LoanTransactionService loanTransactionService, OverdueChargeCutoffDateResolver overdueChargeCutoffDateResolver) {
         return new LoanWritePlatformServiceJpaRepositoryImpl(context, loanTransactionValidator, loanUpdateCommandFromApiJsonDeserializer,
                 loanRepositoryWrapper, loanAccountDomainService, noteRepository, loanTransactionRepository,
                 loanTransactionRelationRepository, loanAssembler, calendarInstanceRepository, paymentDetailWritePlatformService,
@@ -474,7 +474,7 @@ public class LoanAccountConfiguration {
                 loanTransactionAssembler, loanAccrualsProcessingService, loanOfficerValidator, loanDownPaymentTransactionValidator,
                 loanDisbursementService, loanScheduleService, loanChargeValidator, loanOfficerService, reprocessLoanTransactionsService,
                 loanAccountService, journalEntryPoster, loanAdjustmentService, loanMapper, loanTransactionProcessingService,
-                loanBalanceService, loanTransactionService);
+                loanBalanceService, loanTransactionService, overdueChargeCutoffDateResolver);
     }
 
     @Bean

--- a/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/impl/MigrationCutoffReprocessTest.java
+++ b/fineract-provider/src/test/java/org/apache/fineract/portfolio/loanaccount/domain/transactionprocessor/impl/MigrationCutoffReprocessTest.java
@@ -1,0 +1,289 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.portfolio.loanaccount.domain.transactionprocessor.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.fineract.infrastructure.businessdate.domain.BusinessDateType;
+import org.apache.fineract.infrastructure.core.domain.ActionContext;
+import org.apache.fineract.infrastructure.core.domain.ExternalId;
+import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
+import org.apache.fineract.infrastructure.core.service.ExternalIdFactory;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
+import org.apache.fineract.organisation.monetary.domain.Money;
+import org.apache.fineract.organisation.monetary.domain.MoneyHelper;
+import org.apache.fineract.organisation.office.domain.Office;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanCharge;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanChargePaidBy;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanTransaction;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionToRepaymentScheduleMapping;
+import org.apache.fineract.portfolio.loanaccount.serialization.LoanChargeValidator;
+import org.apache.fineract.portfolio.loanaccount.service.LoanBalanceService;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for the migration-cutoff guard in
+ * {@link org.apache.fineract.portfolio.loanaccount.domain.transactionprocessor.AbstractLoanRepaymentScheduleTransactionProcessor#reprocessLoanTransactions
+ * reprocessLoanTransactions(...migrationCutoffDate)}.
+ *
+ * <p>
+ * Behaviour under test: when {@code migrationCutoffDate} is non-null, transactions with
+ * {@code transactionDate < migrationCutoffDate} are replayed via their stored
+ * {@link LoanTransactionToRepaymentScheduleMapping} rows (strategy bypassed); transactions on or after the cutoff flow
+ * through the strategy. When {@code migrationCutoffDate} is null, behaviour matches the cutoff-unaware overload.
+ * </p>
+ */
+@ExtendWith(MockitoExtension.class)
+public class MigrationCutoffReprocessTest {
+
+    private static final MonetaryCurrency CURRENCY = new MonetaryCurrency("USD", 2, 1);
+    private static final MockedStatic<MoneyHelper> MONEY_HELPER = Mockito.mockStatic(MoneyHelper.class);
+
+    private static final LocalDate DISBURSEMENT_DATE = LocalDate.of(2022, 7, 11);
+    private static final LocalDate MIGRATION_CUTOFF = LocalDate.of(2024, 6, 1);
+    private static final LocalDate PRE_CUTOFF_TXN_DATE = LocalDate.of(2022, 9, 30);
+    private static final LocalDate POST_CUTOFF_TXN_DATE = LocalDate.of(2024, 8, 15);
+
+    private OverdueDueAdvInterestPrincipalOverdueDuePenaltiesFeesOrderLoanRepaymentScheduleTransactionProcessor underTest;
+
+    @Mock
+    private Office office;
+
+    @Mock
+    private Loan loan;
+
+    @Mock
+    private LoanChargeValidator loanChargeValidator;
+
+    @Mock
+    private LoanBalanceService loanBalanceService;
+
+    @BeforeAll
+    public static void init() {
+        MONEY_HELPER.when(MoneyHelper::getMathContext).thenReturn(new MathContext(12, RoundingMode.HALF_EVEN));
+        MONEY_HELPER.when(MoneyHelper::getRoundingMode).thenReturn(RoundingMode.HALF_EVEN);
+    }
+
+    @AfterAll
+    public static void destruct() {
+        MONEY_HELPER.close();
+    }
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new OverdueDueAdvInterestPrincipalOverdueDuePenaltiesFeesOrderLoanRepaymentScheduleTransactionProcessor(
+                Mockito.mock(ExternalIdFactory.class), loanChargeValidator, loanBalanceService);
+        ThreadLocalContextUtil.setTenant(new FineractPlatformTenant(1L, "default", "Default", "Asia/Kolkata", null));
+        ThreadLocalContextUtil.setActionContext(ActionContext.DEFAULT);
+        ThreadLocalContextUtil
+                .setBusinessDates(new java.util.HashMap<>(java.util.Map.of(BusinessDateType.BUSINESS_DATE, POST_CUTOFF_TXN_DATE)));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        ThreadLocalContextUtil.reset();
+    }
+
+    @Test
+    public void migratedTransactionWithPenaltyMapping_isReplayedViaMapping_strategyBypassed() {
+        // Spy installment: stub payPenaltyChargesComponent to act as if 590 is outstanding (the production
+        // wrapper.reprocess
+        // would normally load this from LoanCharge rows, which we mock-bypass here for unit-test focus).
+        final LoanRepaymentScheduleInstallment installment = spy(
+                new LoanRepaymentScheduleInstallment(loan, 1, DISBURSEMENT_DATE, LocalDate.of(2022, 10, 5), BigDecimal.valueOf(2500),
+                        BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.valueOf(590), false, null, BigDecimal.ZERO));
+        final List<LoanRepaymentScheduleInstallment> installments = new ArrayList<>(List.of(installment));
+
+        // Pre-cutoff repayment of 590 with stored mapping: penalty=590, all others zero.
+        final Money fiveNinety = Money.of(CURRENCY, BigDecimal.valueOf(590));
+        final Money zero = Money.zero(CURRENCY);
+        Mockito.doReturn(fiveNinety).when(installment).payPenaltyChargesComponent(any(LocalDate.class), any(Money.class));
+
+        final LoanTransaction migratedTxn = spy(
+                LoanTransaction.repayment(office, fiveNinety, null, PRE_CUTOFF_TXN_DATE, ExternalId.empty()));
+        Mockito.lenient().when(migratedTxn.getLoan()).thenReturn(loan);
+        Mockito.lenient().when(loan.getId()).thenReturn(42L);
+
+        final LoanTransactionToRepaymentScheduleMapping mapping = LoanTransactionToRepaymentScheduleMapping.createFrom(migratedTxn,
+                installment, zero, zero, zero, fiveNinety);
+        migratedTxn.getLoanTransactionToRepaymentScheduleMappings().add(mapping);
+
+        underTest.reprocessLoanTransactions(DISBURSEMENT_DATE, new ArrayList<>(List.of(migratedTxn)), CURRENCY, installments,
+                new HashSet<>(), MIGRATION_CUTOFF);
+
+        // Migrated txn must apply penalty 590 directly to the mapped installment.
+        verify(installment, times(1)).payPenaltyChargesComponent(eq(PRE_CUTOFF_TXN_DATE), refEq(fiveNinety));
+        // Strategy first-pass (principal across all) MUST NOT touch principal for a migrated txn.
+        verify(installment, never()).payPrincipalComponent(eq(PRE_CUTOFF_TXN_DATE), any(Money.class));
+        verify(installment, never()).payInterestComponent(eq(PRE_CUTOFF_TXN_DATE), any(Money.class));
+        verify(installment, never()).payFeeChargesComponent(eq(PRE_CUTOFF_TXN_DATE), any(Money.class));
+    }
+
+    @Test
+    public void migratedTransactionWithBadComponentSum_isSkippedNotApplied() {
+        final LoanRepaymentScheduleInstallment installment = spy(
+                new LoanRepaymentScheduleInstallment(loan, 1, DISBURSEMENT_DATE, LocalDate.of(2022, 10, 5), BigDecimal.valueOf(2500),
+                        BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.valueOf(590), false, null, BigDecimal.ZERO));
+        final List<LoanRepaymentScheduleInstallment> installments = new ArrayList<>(List.of(installment));
+
+        // Transaction amount = 590, but mapping says principal=100, penalty=100 (sum=200) — inconsistent.
+        final Money txnAmount = Money.of(CURRENCY, BigDecimal.valueOf(590));
+        final Money hundred = Money.of(CURRENCY, BigDecimal.valueOf(100));
+        final Money zero = Money.zero(CURRENCY);
+        final LoanTransaction badMigratedTxn = spy(
+                LoanTransaction.repayment(office, txnAmount, null, PRE_CUTOFF_TXN_DATE, ExternalId.empty()));
+        when(badMigratedTxn.getLoan()).thenReturn(loan);
+
+        final LoanTransactionToRepaymentScheduleMapping mapping = LoanTransactionToRepaymentScheduleMapping.createFrom(badMigratedTxn,
+                installment, hundred, zero, zero, hundred);
+        badMigratedTxn.getLoanTransactionToRepaymentScheduleMappings().add(mapping);
+
+        underTest.reprocessLoanTransactions(DISBURSEMENT_DATE, new ArrayList<>(List.of(badMigratedTxn)), CURRENCY, installments,
+                new HashSet<>(), MIGRATION_CUTOFF);
+
+        // No payXxxComponent calls — txn was skipped due to sum mismatch.
+        verify(installment, never()).payPrincipalComponent(any(LocalDate.class), any(Money.class));
+        verify(installment, never()).payInterestComponent(any(LocalDate.class), any(Money.class));
+        verify(installment, never()).payFeeChargesComponent(any(LocalDate.class), any(Money.class));
+        verify(installment, never()).payPenaltyChargesComponent(any(LocalDate.class), any(Money.class));
+    }
+
+    @Test
+    public void nullCutoff_treatsAllTransactionsAsCurrent_strategyRuns() {
+        final LoanRepaymentScheduleInstallment installment = spy(
+                new LoanRepaymentScheduleInstallment(loan, 1, DISBURSEMENT_DATE, LocalDate.of(2022, 10, 5), BigDecimal.valueOf(2500),
+                        BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.valueOf(590), false, null, BigDecimal.ZERO));
+        final List<LoanRepaymentScheduleInstallment> installments = new ArrayList<>(List.of(installment));
+
+        // Pre-cutoff dated repayment of 590, but no cutoff configured.
+        final Money txnAmount = Money.of(CURRENCY, BigDecimal.valueOf(590));
+        final LoanTransaction txn = spy(LoanTransaction.repayment(office, txnAmount, null, PRE_CUTOFF_TXN_DATE, ExternalId.empty()));
+        Mockito.lenient().when(txn.getLoan()).thenReturn(loan);
+        Mockito.lenient().when(loan.getRepaymentScheduleInstallments()).thenReturn(installments);
+
+        underTest.reprocessLoanTransactions(DISBURSEMENT_DATE, new ArrayList<>(List.of(txn)), CURRENCY, installments, new HashSet<>(),
+                null);
+
+        // Strategy first-pass (principal across all installments) MUST be invoked — principal of 590 applied to
+        // installment 1 since principal is highest priority for this strategy.
+        verify(installment, times(1)).payPrincipalComponent(eq(PRE_CUTOFF_TXN_DATE), any(Money.class));
+        // And NO penalty is paid (would have been the FinFlux allocation, but strategy reallocates).
+        verify(installment, never()).payPenaltyChargesComponent(eq(PRE_CUTOFF_TXN_DATE), any(Money.class));
+    }
+
+    @Test
+    public void migratedTransactionWithChargePaidBy_relinksLoanChargeAmountPaid() {
+        final LoanRepaymentScheduleInstallment installment = spy(
+                new LoanRepaymentScheduleInstallment(loan, 1, DISBURSEMENT_DATE, LocalDate.of(2022, 10, 5), BigDecimal.ZERO,
+                        BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.valueOf(590), false, null, BigDecimal.ZERO));
+        final List<LoanRepaymentScheduleInstallment> installments = new ArrayList<>(List.of(installment));
+
+        final LoanCharge penaltyCharge = Mockito.mock(LoanCharge.class);
+        when(penaltyCharge.isDueAtDisbursement()).thenReturn(false);
+        final Set<LoanCharge> charges = new HashSet<>();
+        charges.add(penaltyCharge);
+
+        final Money fiveNinety = Money.of(CURRENCY, BigDecimal.valueOf(590));
+        final Money zero = Money.zero(CURRENCY);
+        final LoanTransaction migratedTxn = spy(
+                LoanTransaction.repayment(office, fiveNinety, null, PRE_CUTOFF_TXN_DATE, ExternalId.empty()));
+        when(migratedTxn.getLoan()).thenReturn(loan);
+
+        // Mapping: penalty=590, others zero
+        final LoanTransactionToRepaymentScheduleMapping mapping = LoanTransactionToRepaymentScheduleMapping.createFrom(migratedTxn,
+                installment, zero, zero, zero, fiveNinety);
+        migratedTxn.getLoanTransactionToRepaymentScheduleMappings().add(mapping);
+
+        // ChargePaidBy linking the 590 to the penalty charge
+        final LoanChargePaidBy chargePaidBy = new LoanChargePaidBy(migratedTxn, penaltyCharge, BigDecimal.valueOf(590), null,
+                RoundingMode.HALF_EVEN);
+        migratedTxn.getLoanChargesPaid().add(chargePaidBy);
+
+        underTest.reprocessLoanTransactions(DISBURSEMENT_DATE, new ArrayList<>(List.of(migratedTxn)), CURRENCY, installments, charges,
+                MIGRATION_CUTOFF);
+
+        // Charge.updatePaidAmountBy must be called with the migrated paid amount.
+        verify(penaltyCharge, times(1)).updatePaidAmountBy(refEq(fiveNinety), any(), refEq(fiveNinety));
+        // The charge is reset at the start of reprocess (resetPaidAmount), then re-linked by our replay.
+        verify(penaltyCharge, times(1)).resetPaidAmount(CURRENCY);
+    }
+
+    /**
+     * Pre-cutoff transactions whose semantics do not map to paid-amount methods (e.g., write-off, charges waiver,
+     * interest waiver) must NOT be replayed via {@code installment.payXxxComponent}; they need to flow through the
+     * strategy / specific handlers so the correct fields (e.g., {@code principalWrittenOff}, {@code feeChargesWaived})
+     * are populated.
+     */
+    @Test
+    public void preCutoffWriteOff_isNotReplayedViaPayComponents() {
+        final LoanRepaymentScheduleInstallment installment = spy(
+                new LoanRepaymentScheduleInstallment(loan, 1, DISBURSEMENT_DATE, LocalDate.of(2022, 10, 5), BigDecimal.valueOf(2500),
+                        BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO, false, null, BigDecimal.ZERO));
+        final List<LoanRepaymentScheduleInstallment> installments = new ArrayList<>(List.of(installment));
+
+        // Build a pre-cutoff WRITE_OFF transaction with a mapping (as migration might have created).
+        final Money writeOffAmount = Money.of(CURRENCY, BigDecimal.valueOf(2500));
+        final Money zero = Money.zero(CURRENCY);
+        final LoanTransaction writeOffTxn = spy(LoanTransaction.writeoff(loan, office, PRE_CUTOFF_TXN_DATE, ExternalId.empty()));
+        Mockito.lenient().when(writeOffTxn.getLoan()).thenReturn(loan);
+        // Force amount so the txn has a numeric value (writeoff constructor leaves amount null in test).
+        Mockito.lenient().doReturn(writeOffAmount).when(writeOffTxn).getAmount(any(MonetaryCurrency.class));
+
+        final LoanTransactionToRepaymentScheduleMapping mapping = LoanTransactionToRepaymentScheduleMapping.createFrom(writeOffTxn,
+                installment, writeOffAmount, zero, zero, zero);
+        writeOffTxn.getLoanTransactionToRepaymentScheduleMappings().add(mapping);
+
+        underTest.reprocessLoanTransactions(DISBURSEMENT_DATE, new ArrayList<>(List.of(writeOffTxn)), CURRENCY, installments,
+                new HashSet<>(), MIGRATION_CUTOFF);
+
+        // Write-off must NOT be applied via paid-amount methods. principalCompleted must stay zero — the principal is
+        // written off, not paid.
+        verify(installment, never()).payPrincipalComponent(any(LocalDate.class), any(Money.class));
+        verify(installment, never()).payInterestComponent(any(LocalDate.class), any(Money.class));
+        verify(installment, never()).payFeeChargesComponent(any(LocalDate.class), any(Money.class));
+        verify(installment, never()).payPenaltyChargesComponent(any(LocalDate.class), any(Money.class));
+    }
+}


### PR DESCRIPTION
Daily penal job triggers a full reprocess that resets all installment derived components and replays every historical transaction through the configured strategy.

Introduce a migration-cutoff-aware reprocess overload that, for loans within the migrated range, replays pre-cutoff repayment-like and charge-payment transactions via their stored
LoanTransactionToRepaymentScheduleMapping rows and LoanChargePaidBy links instead of the strategy. Non-replayable pre-cutoff transaction types (write-off, refund, chargeback, charge-off, interest waiver, credit balance refund) continue to flow through the strategy and their existing handlers so semantics like principalWrittenOff are preserved. Non-migrated loans take the original code path with cutoff null.

Cutoff is resolved per loan via the existing
OverdueChargeCutoffDateResolver (gated by FINERACT_MIGRATION_CUTOFF_DATE and FINERACT_MIGRATION_LAST_IMPORTED_LOAN_ID). Plumbed through ReprocessLoanTransactionsService, LoanTransactionProcessingService, the chargeback path in LoanWritePlatformServiceJpaRepositoryImpl, and processPostDisbursementTransactions. AdvancedPaymentScheduleTransaction Processor is out of scope and logs a warn when a migrated loan hits it.

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
